### PR TITLE
support excluding routes from versioning

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,15 @@ module.exports = function (options) {
   options = options || {};
 
   options.prefix = options.prefix || '';
+  options.exclude = options.exclude || null;
 
   return function (req, res, next) {
     req.originalUrl = req.url;
+
+    if (options.exclude instanceof RegExp && options.exclude.test(req.originalUrl)) {
+      return next();
+    }
+
     req.url = req.url.replace(options.prefix, '');
 
     var pieces = req.url.replace(/^\/+/, '').split('/');

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,23 @@ Now these formats are available:
 + `[protocol]://[host]/api/v[x].[y]/foo`
 + `[protocol]://[host]/api/v[x].[y].[z]/foo`
 
+To exclude routes from being versioned, pass a regular expression that matches
+routes to exclude for the `exclude` option:
+
+```js
+// Add restify-url-semver middleware
+server.pre(versioning({ prefix: '/api', exclude: /healthcheck/ }));
+
+// [protocol]://[host]/healthcheck
+server.get({ path: '/healthcheck' }, function (req, res, next) {
+  res.send(200);
+});
+
+// [protocol]://[host]/api/v1/foo
+server.get({ path: '/foo', version: '1.0.0' }, function (req, res, next) {
+  console.log(req.headers['accept-version']); // 1.0.0
+});
+```
 
 ## License
 


### PR DESCRIPTION
Hi, thanks for this lib. The use case I'm trying to support with this PR is to exclude routes from being versioned, like a healthcheck route that is called from ELB or something similar. In my case the healthcheck is version agnostic because it tests the health of _all_ versions to determine system health; not one version in particular. 
