### PR TITLE
Fix version stripping.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function (options) {
     version = version.replace(/v(\d{1})/, '$1.0.0')
 
     if (semver.valid(version)) {
-      req.url = req.url.replace(pieces[0], '')
+      req.url = req.url.substr(pieces[0].length + 1)
       req.headers = req.headers || []
       req.headers['accept-version'] = version
     } else {


### PR DESCRIPTION
Previously double forward slashes were being
left behind since only the version string itself
was being removed. This version is also more
efficient since it doesn't have to inspect the
string to operate.